### PR TITLE
Added user logging into the db and humored rubocop

### DIFF
--- a/modules/auxiliary/gather/kerberos_enumusers.rb
+++ b/modules/auxiliary/gather/kerberos_enumusers.rb
@@ -7,47 +7,52 @@ require 'msf/core'
 require 'rex'
 
 class MetasploitModule < Msf::Auxiliary
-
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::Kerberos::Client
 
   def initialize(info = {})
     super(update_info(info,
       'Name' => 'Kerberos Domain User Enumeration',
-      'Description' => %q{
+      'Description' => %q(
         This module will enumerate valid Domain Users via Kerberos from an unauthenticated perspective. It utilises
         the different responses returned by the service for valid and invalid users.
-      },
+      ),
       'Author' =>
         [
           'Matt Byrne <attackdebris[at]gmail.com>' # Metasploit module
         ],
       'References' =>
         [
-          [ 'URL', 'https://nmap.org/nsedoc/scripts/krb5-enum-users.html'],
+          [ 'URL', 'https://nmap.org/nsedoc/scripts/krb5-enum-users.html']
         ],
-      'License' => MSF_LICENSE,
-    ))
+      'License' => MSF_LICENSE
+      )
+    )
 
     register_options(
       [
         OptString.new('DOMAIN', [ true, 'The Domain Eg: demo.local' ]),
         OptPath.new(
           'USER_FILE',
-      [true, 'Files containing usernames, one per line', nil])
-      ], self.class)
+          [true, 'Files containing usernames, one per line', nil]
+        )
+      ],
+      self.class
+    )
   end
+
   def user_list
     users = nil
     if File.readable? datastore['USER_FILE']
       users = File.new(datastore['USER_FILE']).read.split
-      users.each {|u| u.downcase!}
+      users.each { |u| u.downcase! }
       users.uniq!
     else
       raise ArgumentError, "Cannot read file #{datastore['USER_FILE']}"
-  end
+    end
     users
   end
+
   def run
     print_status("Validating options...")
 
@@ -67,23 +72,52 @@ class MetasploitModule < Msf::Auxiliary
         server_name: "krbtgt/#{domain}",
         realm: "#{domain}",
         pa_data: pre_auth
-    )
-    print_status("#{peer} - #{warn_error(res)}") if res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR
-    test = Rex::Proto::Kerberos::Model::ERROR_CODES[res.error_code]
-    if test == ["KDC_ERR_PREAUTH_REQUIRED", "Additional pre-authentication required"]
-      print_good("#{peer} - User: \"#{user}\" is present")
-    elsif test == ["KDC_ERR_CLIENT_REVOKED", "Clients credentials have been revoked"]
-      print_error("#{peer} - User: \"#{user}\" account disabled or locked out")
-    else
-      print_status("#{peer} - User: \"#{user}\" does not exist")
+      )
+      print_status("#{peer} - #{warn_error(res)}") if res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR
+      test = Rex::Proto::Kerberos::Model::ERROR_CODES[res.error_code]
+      if test == ["KDC_ERR_PREAUTH_REQUIRED", "Additional pre-authentication required"]
+        print_good("#{peer} - User: \"#{user}\" is present")
+        report_cred(
+          host: datastore['RHOST'],
+          port: rport,
+          creds_name: 'Active Directory',
+          user: user
+        )
+      elsif test == ["KDC_ERR_CLIENT_REVOKED", "Clients credentials have been revoked"]
+        print_error("#{peer} - User: \"#{user}\" account disabled or locked out")
+      else
+        print_status("#{peer} - User: \"#{user}\" does not exist")
+      end
     end
   end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:host],
+      port: opts[:port],
+      protocol: 'udp',
+      workspace_id: myworkspace.id,
+      service_name: opts[:creds_name]
+    }
+
+    credential_data = {
+      username: opts[:user],
+      origin_type: :service,
+      module_fullname: self.fullname
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def warn_error(res)
     msg = ''
 
-    if Rex::Proto::Kerberos::Model::ERROR_CODES.has_key?(res.error_code)
+    if Rex::Proto::Kerberos::Model::ERROR_CODES.key?(res.error_code)
       error_info = Rex::Proto::Kerberos::Model::ERROR_CODES[res.error_code]
       msg = "#{error_info[0]} - #{error_info[1]}"
     else


### PR DESCRIPTION
Hey there!
I used this PR as an excuse to learn how we log creds into the database.  I added the code to report the creds, so if the username exists, it gets added to the db.

Also, I made some minor stylistic changes suggested by rubocop to try and maintain a common style among modules.

Please check it out and merge if you are OK with it.

Thanks again!

Test Run:

```
USER_FILE => /home/bwatters/rapid7/userlist
msf auxiliary(kerberos_enumusers) > run

[*] Validating options...
[*] Using domain: домен...
[*] <RU_DC_IP>:88 - Testing User: "пользователь"...
[*] <RU_DC_IP>:88 - KDC_ERR_C_PRINCIPAL_UNKNOWN - Client not found in Kerberos database
[*] <RU_DC_IP>:88 - User: "пользователь" does not exist
[*] <RU_DC_IP>:88 - Testing User: "пользователь1"...
[*] <RU_DC_IP>:88 - KDC_ERR_PREAUTH_REQUIRED - Additional pre-authentication required
[+] <RU_DC_IP>:88 - User: "пользователь1" is present
[*] <RU_DC_IP>:88 - Testing User: "пользователь2"...
[*] <RU_DC_IP>:88 - KDC_ERR_PREAUTH_REQUIRED - Additional pre-authentication required
[+] <RU_DC_IP>:88 - User: "пользователь2" is present
[*] <RU_DC_IP>:88 - Testing User: "администратор"...
[*] <RU_DC_IP>:88 - KDC_ERR_PREAUTH_REQUIRED - Additional pre-authentication required
[+] <RU_DC_IP>:88 - User: "администратор" is present
[*] Auxiliary module execution completed
msf auxiliary(kerberos_enumusers) > show options

Module options (auxiliary/gather/kerberos_enumusers):

   Name       Current Setting                 Required  Description
   ----       ---------------                 --------  -----------
   DOMAIN     домен                      yes       The Domain Eg: demo.local
   RHOST      <RU_DC_IP>                  yes       The target address
   RPORT      88                              yes       The target port
   Timeout    10                              yes       The TCP timeout to establish connection and read data
   USER_FILE  /home/bwatters/rapid7/userlist  yes       Files containing usernames, one per line

msf auxiliary(kerberos_enumusers) > creds
Credentials
===========

host            origin          service                    public                      private  realm  private_type
----            ------          -------                    ------                      -------  -----  ------------
<RU_DC_IP>  <RU_DC_IP>  88/udp (Active Directory)  пользователь1                   
<RU_DC_IP>  <RU_DC_IP>  88/udp (Active Directory)  пользователь2                   
<RU_DC_IP>  <RU_DC_IP>  88/udp (Active Directory)  администратор                  

msf auxiliary(kerberos_enumusers) > set rhost <EN_DC_IP>
rhost => <EN_DC_IP>
msf auxiliary(kerberos_enumusers) > set domain test
domain => test
msf auxiliary(kerberos_enumusers) > set USER_FILE /home/bwatters/rapid7/users_en
USER_FILE => /home/bwatters/rapid7/users_en
msf auxiliary(kerberos_enumusers) > show options

Module options (auxiliary/gather/kerberos_enumusers):

   Name       Current Setting                 Required  Description
   ----       ---------------                 --------  -----------
   DOMAIN     test                            yes       The Domain Eg: demo.local
   RHOST      <EN_DC_IP>                  yes       The target address
   RPORT      88                              yes       The target port
   Timeout    10                              yes       The TCP timeout to establish connection and read data
   USER_FILE  /home/bwatters/rapid7/users_en  yes       Files containing usernames, one per line

msf auxiliary(kerberos_enumusers) > run

[*] Validating options...
[*] Using domain: TEST...
[*] <EN_DC_IP>:88 - Testing User: "ppotts"...
[*] <EN_DC_IP>:88 - KDC_ERR_PREAUTH_REQUIRED - Additional pre-authentication required
[+] <EN_DC_IP>:88 - User: "ppotts" is present
[*] <EN_DC_IP>:88 - Testing User: "loki"...
[*] <EN_DC_IP>:88 - KDC_ERR_C_PRINCIPAL_UNKNOWN - Client not found in Kerberos database
[*] <EN_DC_IP>:88 - User: "loki" does not exist
[*] <EN_DC_IP>:88 - Testing User: "bbanner"...
[*] <EN_DC_IP>:88 - KDC_ERR_PREAUTH_REQUIRED - Additional pre-authentication required
[+] <EN_DC_IP>:88 - User: "bbanner" is present
[*] <EN_DC_IP>:88 - Testing User: "ultron"...
[*] <EN_DC_IP>:88 - KDC_ERR_C_PRINCIPAL_UNKNOWN - Client not found in Kerberos database
[*] <EN_DC_IP>:88 - User: "ultron" does not exist
[*] <EN_DC_IP>:88 - Testing User: "rracoon"...
[*] <EN_DC_IP>:88 - KDC_ERR_C_PRINCIPAL_UNKNOWN - Client not found in Kerberos database
[*] <EN_DC_IP>:88 - User: "rracoon" does not exist
[*] <EN_DC_IP>:88 - Testing User: "hzemo"...
[*] <EN_DC_IP>:88 - KDC_ERR_C_PRINCIPAL_UNKNOWN - Client not found in Kerberos database
[*] <EN_DC_IP>:88 - User: "hzemo" does not exist
[*] <EN_DC_IP>:88 - Testing User: "iheartshells"...
[*] <EN_DC_IP>:88 - KDC_ERR_PREAUTH_REQUIRED - Additional pre-authentication required
[+] <EN_DC_IP>:88 - User: "iheartshells" is present
[*] <EN_DC_IP>:88 - Testing User: "ddoom"...
[*] <EN_DC_IP>:88 - KDC_ERR_C_PRINCIPAL_UNKNOWN - Client not found in Kerberos database
[*] <EN_DC_IP>:88 - User: "ddoom" does not exist
[*] <EN_DC_IP>:88 - Testing User: "cbarton"...
[*] <EN_DC_IP>:88 - KDC_ERR_PREAUTH_REQUIRED - Additional pre-authentication required
[+] <EN_DC_IP>:88 - User: "cbarton" is present
[*] <EN_DC_IP>:88 - Testing User: "kang"...
[*] <EN_DC_IP>:88 - KDC_ERR_C_PRINCIPAL_UNKNOWN - Client not found in Kerberos database
[*] <EN_DC_IP>:88 - User: "kang" does not exist
[*] <EN_DC_IP>:88 - Testing User: "mhill"...
[*] <EN_DC_IP>:88 - KDC_ERR_PREAUTH_REQUIRED - Additional pre-authentication required
[+] <EN_DC_IP>:88 - User: "mhill" is present
[*] <EN_DC_IP>:88 - Testing User: "kree"...
[*] <EN_DC_IP>:88 - KDC_ERR_C_PRINCIPAL_UNKNOWN - Client not found in Kerberos database
[*] <EN_DC_IP>:88 - User: "kree" does not exist
[*] <EN_DC_IP>:88 - Testing User: "nromanoff"...
[*] <EN_DC_IP>:88 - KDC_ERR_PREAUTH_REQUIRED - Additional pre-authentication required
[+] <EN_DC_IP>:88 - User: "nromanoff" is present
[*] <EN_DC_IP>:88 - Testing User: "pcoulson"...
[*] <EN_DC_IP>:88 - KDC_ERR_PREAUTH_REQUIRED - Additional pre-authentication required
[+] <EN_DC_IP>:88 - User: "pcoulson" is present
[*] <EN_DC_IP>:88 - Testing User: "srogers"...
[*] <EN_DC_IP>:88 - KDC_ERR_PREAUTH_REQUIRED - Additional pre-authentication required
[+] <EN_DC_IP>:88 - User: "srogers" is present
[*] <EN_DC_IP>:88 - Testing User: "tstark"...
[*] <EN_DC_IP>:88 - KDC_ERR_PREAUTH_REQUIRED - Additional pre-authentication required
[+] <EN_DC_IP>:88 - User: "tstark" is present
[*] Auxiliary module execution completed
msf auxiliary(kerberos_enumusers) > creds
Credentials
===========

host            origin          service                    public                      private  realm  private_type
----            ------          -------                    ------                      -------  -----  ------------
<RU_DC_IP>  <RU_DC_IP>  88/udp (Active Directory)  пользователь1                   
<RU_DC_IP>  <RU_DC_IP>  88/udp (Active Directory)  пользователь2                   
<RU_DC_IP>  <RU_DC_IP>  88/udp (Active Directory)  администратор                  
<EN_DC_IP>  <EN_DC_IP>  88/udp (Active Directory)  ppotts                                      
<EN_DC_IP>  <EN_DC_IP>  88/udp (Active Directory)  bbanner                                     
<EN_DC_IP>  <EN_DC_IP>  88/udp (Active Directory)  iheartshells                                
<EN_DC_IP>  <EN_DC_IP>  88/udp (Active Directory)  cbarton                                     
<EN_DC_IP>  <EN_DC_IP>  88/udp (Active Directory)  mhill                                       
<EN_DC_IP>  <EN_DC_IP>  88/udp (Active Directory)  nromanoff                                   
<EN_DC_IP>  <EN_DC_IP>  88/udp (Active Directory)  pcoulson                                    
<EN_DC_IP>  <EN_DC_IP>  88/udp (Active Directory)  srogers                                     
<EN_DC_IP>  <EN_DC_IP>  88/udp (Active Directory)  tstark                                      

msf auxiliary(kerberos_enumusers) > exit
```
